### PR TITLE
Implement WebSocket Heartbeat Tracking and Stale Connection Cleanup

### DIFF
--- a/App.py
+++ b/App.py
@@ -125,6 +125,14 @@ async def startup_event():
         print("Scheduler started successfully")
         logger.info("Scheduler started successfully")
 
+        # Start WebSocket timeout monitor
+        async def monitor_websockets():
+            while True:
+                connection_manager.prune_stale_connections()
+                await asyncio.sleep(30)
+
+        asyncio.create_task(monitor_websockets())
+
     except Exception as e:
         error_msg = f"Error during startup: {str(e)}"
         print(error_msg)

--- a/frontend/src/FileUploader.js
+++ b/frontend/src/FileUploader.js
@@ -163,6 +163,18 @@ const FileUploader = ({ onFilesSelected }) => {
     };
   }, []);
 
+  // WebSocket heartbeat effect
+  useEffect(() => {
+    const clientId = getClientId();
+    const heartbeatInterval = setInterval(() => {
+      if (websocket?.readyState === WebSocket.OPEN) {
+        websocket.send(JSON.stringify({ event: "heartbeat", client_id: clientId }));
+      }
+    }, 30000); // every 30s
+
+    return () => clearInterval(heartbeatInterval);
+  }, [websocket]);
+
   /**
    * Toggle mobile navigation drawer
    */

--- a/routers/websocket.py
+++ b/routers/websocket.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from utils.ws_manager import connection_manager
 import uuid
 import logging
+import json
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
@@ -17,8 +18,18 @@ async def websocket_endpoint(websocket: WebSocket, client_id: str):
 
         while True:
             data = await websocket.receive_text()
-            logger.info(f"Received from {client_id}: {data}")
-            await websocket.send_text(f"Echo from server: {data}")
+
+            try:
+                message = json.loads(data)
+                if message.get("event") == "heartbeat":
+                    logger.debug(f"Heartbeat received from {client_id}")
+                    connection_manager.mark_alive(client_id)
+                else:
+                    logger.info(f"Received from {client_id}: {data}")
+                    await websocket.send_text(f"Echo from server: {data}")
+            except json.JSONDecodeError:
+                logger.info(f"Received non-JSON from {client_id}: {data}")
+                await websocket.send_text(f"Echo from server: {data}")
 
     except WebSocketDisconnect:
         connection_manager.disconnect_client(client_id)


### PR DESCRIPTION
## 🚀 Implement WebSocket Heartbeat Tracking and Stale Connection Cleanup

This PR introduces client liveness tracking and automated cleanup for inactive WebSocket clients to improve server-side resource management.

---

### ✨ Features

- **💓 Heartbeat Mechanism**
  - Frontend now sends a `heartbeat` event via WebSocket every 30 seconds.
  - Ensures server knows client is still connected and responsive.

- **⏳ Stale Connection Detection**
  - Server tracks the timestamp of the last heartbeat for each client.
  - Clients that haven't sent a heartbeat in over 90 seconds are considered stale.

- **🧹 Auto-Pruning Task**
  - A background task `monitor_websockets` runs every 30 seconds.
  - It prunes all stale WebSocket connections automatically.

- **🪵 Improved Logging**
  - Added logs for:
    - Heartbeat receipt
    - Client marked alive
    - Disconnected or stale clients being cleaned up

---

### ✅ Benefits

- Prevents resource leaks from dead/inactive WebSocket clients.
- Improves scalability and performance for real-time dashboards.
- Lays groundwork for future client activity analytics.

---

### 🧪 How to Test

1. Run the app and connect via WebSocket using the frontend.
2. Monitor logs for heartbeat events and client timestamps.
3. Close the frontend tab or disable heartbeats — after 90s, the connection should be pruned automatically.

---

### 📁 Affected Modules

- `frontend/src/FileUploader.js`  
- `routers/websocket.py`  
- `utils/ws_manager.py`  
- `App.py`

---

:rocket: Ready for review!
